### PR TITLE
Change position of type tooltip to be consistent with the edit tooltip

### DIFF
--- a/src/course-viewer/AssessmentViewerCard.jsx
+++ b/src/course-viewer/AssessmentViewerCard.jsx
@@ -87,7 +87,7 @@ const AssessmentViewerCard = (props) => {
                             </Typography>
                         </Tooltip>
                         <Stack direction="row" spacing={1} sx={{ alignSelf: "baseline", alignItems:"center" }}>
-                            <Tooltip title={isMobile ? "" : <h3> { assData.isAss ? "Assignment" : "Test" } </h3>} placement="right" arrow>
+                            <Tooltip title={isMobile ? "" : <h3> { assData.isAss ? "Assignment" : "Test" } </h3>} placement="bottom" arrow>
                                 {   assData.isAss ? 
                                     <MenuBookRoundedIcon /> :
                                     <DescriptionRoundedIcon /> 

--- a/src/course-viewer/AssessmentViewerCard.jsx
+++ b/src/course-viewer/AssessmentViewerCard.jsx
@@ -81,7 +81,7 @@ const AssessmentViewerCard = (props) => {
             <CardContent sx={{ display: "flex" }}>
                 <Stack spacing={1}>
                     <Stack direction="row" sx={{ display:"flex", minWidth: isMobile ? 310 : 350 }}>
-                        <Tooltip title={<h3> { assData.name === "" ? "..." : assData.name } </h3>} placement="top" arrow>
+                        <Tooltip title={<h3> { assData.name === "" ? "..." : assData.name } </h3>} placement="top-start" arrow>
                             <Typography variant={"h5"} component="div" sx={[{ flexGrow: 1, width: isMobile ? 200 : 275 }, !isMobile ? { mr: 1, overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" } : { mr: 1 }]}>
                                 { assData.name === "" ? "..." : assData.name }
                             </Typography>


### PR DESCRIPTION
Closes #378 

I've made it so the assessment type and the edit assessment tooltips show below the buttons while the assessment name displays above. I think this is consistent enough as it provides separation between the elements.