### PR TITLE
Refreshes assignment list after syncing

### DIFF
--- a/src/course-viewer/CourseViewer.jsx
+++ b/src/course-viewer/CourseViewer.jsx
@@ -514,6 +514,7 @@ const CourseViewer = (props) => {
                 onClose={(isKeyPress) => {
                     setSyncMenuOpen(false);
                     if(!isKeyPress) setKeyOverride(false);
+                    setAssessments([]);
                 }}
             />
 


### PR DESCRIPTION
**Make sure you're on the main branch**  
To replicate the initial issue, change the weight or date of an assignment in your instance and then sync, accepting all changes. You should see the field you changed has not synced. However, if you refresh the correct value displays.

Pretty sure the issue occurs as the list is displayed before it is updated by the syncing function. The solution was to refresh the assignment list by setting it to empty.