### PR TITLE
Split transcript dialog

### DIFF
--- a/src/overview/GradesOverview.jsx
+++ b/src/overview/GradesOverview.jsx
@@ -35,7 +35,7 @@ import YearOverview from "./YearOverview";
 
 import AddIcon from '@mui/icons-material/Add';
 import DescriptionIcon from '@mui/icons-material/Description';
-import TranscriptDialog from "../TranscriptDialog";
+const TranscriptDialog = React.lazy(() => import("../TranscriptDialog"));
 
 /**
  * One of the 3 main pages of the application. This displays an overview 


### PR DESCRIPTION
Making only TranscriptDialog lazy load seemed to reduce the bundle size significantly.

Before:
![image](https://github.com/Twenty-Three-Fifty-Nine/grade-tracker/assets/52386683/31230b90-70eb-418a-ad77-ea6d6744e039)

After:
![image](https://github.com/Twenty-Three-Fifty-Nine/grade-tracker/assets/52386683/89da4163-b3a6-4aeb-a603-a1b3843af016)
